### PR TITLE
Add "force zipkin tracing" functionality

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -259,6 +259,11 @@
   color: #b00;
 }
 
+.graphiql-container .toolbar-button.activated {
+  background: linear-gradient(#eafeea, #90ee90);
+  color: #008000;
+}
+
 .graphiql-container .toolbar-button-group {
   margin: 0 5px;
   white-space: nowrap;

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -119,6 +119,7 @@ export class GraphiQL extends React.Component {
           DEFAULT_DOC_EXPLORER_WIDTH,
       isWaitingForResponse: false,
       subscription: null,
+      forceTracing: false,
       ...queryFacts,
     };
 
@@ -243,6 +244,8 @@ export class GraphiQL extends React.Component {
       find(children, child => child.type === GraphiQL.Logo) ||
       <GraphiQL.Logo />;
 
+    const tracingLabel = 'Tracing ' + (this.state.forceTracing ? 'On' : 'Off');
+
     const toolbar =
       find(children, child => child.type === GraphiQL.Toolbar) ||
       <GraphiQL.Toolbar>
@@ -255,6 +258,12 @@ export class GraphiQL extends React.Component {
           onClick={this.handleToggleHistory}
           title="Show History"
           label="History"
+        />
+        <ToolbarButton
+          onClick={this.handleForceTracingToggle}
+          active={this.state.forceTracing}
+          title="Tracing"
+          label={tracingLabel}
         />
 
       </GraphiQL.Toolbar>;
@@ -535,7 +544,7 @@ export class GraphiQL extends React.Component {
       });
   }
 
-  _fetchQuery(query, variables, operationName, cb) {
+  _fetchQuery(query, variables, operationName, forceTracing, cb) {
     const fetcher = this.props.fetcher;
     let jsonVariables = null;
 
@@ -555,6 +564,7 @@ export class GraphiQL extends React.Component {
       query,
       variables: jsonVariables,
       operationName,
+      forceTracing,
     });
 
     if (isPromise(fetch)) {
@@ -629,6 +639,7 @@ export class GraphiQL extends React.Component {
         editedQuery,
         variables,
         operationName,
+        this.state.forceTracing,
         result => {
           if (queryID === this._editorQueryID) {
             this.setState({
@@ -946,6 +957,12 @@ export class GraphiQL extends React.Component {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+  };
+
+  handleForceTracingToggle = () => {
+    this.setState({
+      forceTracing: !this.state.forceTracing,
+    });
   };
 }
 

--- a/src/components/ToolbarButton.js
+++ b/src/components/ToolbarButton.js
@@ -19,6 +19,7 @@ export class ToolbarButton extends React.Component {
     onClick: PropTypes.func,
     title: PropTypes.string,
     label: PropTypes.string,
+    active: PropTypes.bool,
   };
 
   constructor(props) {
@@ -28,9 +29,18 @@ export class ToolbarButton extends React.Component {
 
   render() {
     const { error } = this.state;
+    const { active } = this.props;
+
+    let className = 'toolbar-button';
+    if (error) {
+      className += ' error';
+    } else if (active) {
+      className += ' activated';
+    }
+
     return (
       <a
-        className={'toolbar-button' + (error ? ' error' : '')}
+        className={className}
         onMouseDown={preventDefault}
         onClick={this.handleClick}
         title={error ? error.message : this.props.title}>


### PR DESCRIPTION
This adds a button to the toolbar that will toggle zipkin
tracing on and off. When toggled on this adds a field to the
request body called `forceTracing` which will need to be
handled server-side.

<img width="1381" alt="screen shot 2017-12-03 at 10 34 15 am" src="https://user-images.githubusercontent.com/787203/33528460-962a5dd8-d815-11e7-81f2-0666b975f44c.png">
<img width="1381" alt="screen shot 2017-12-03 at 10 34 19 am" src="https://user-images.githubusercontent.com/787203/33528461-9883ab48-d815-11e7-95c1-97209ed7b57d.png">
